### PR TITLE
fix: 선택 사항이 "" 으로 입력될 경우 가장 짧은 이름을 검색하는 오류 해결

### DIFF
--- a/backend/movies/functions.py
+++ b/backend/movies/functions.py
@@ -106,6 +106,12 @@ def get_infos_from_request(request):
     director_strs = request.GET.get('directors', None)
     actor_strs = request.GET.get('actors', None)
 
+    if director_strs == "":
+        director_strs = None
+
+    if actor_strs == "":
+        actor_strs = None
+
     genre_ids = []
     if genre_strs != None:
         genre_ids = list(map(int, genre_strs.replace(' ', '').split(',')))


### PR DESCRIPTION
## 작업 내용
> 영화 추천 시 선택 사항으로 입력받는 요소들이 아무것도 없는 "" 으로 입력될 경우 가장 짧은 이름을 검색하는 문제가 있었습니다. 이 경우 None 으로 치환해서 정상로직을 수행할 수 있도록 하였습니다.