### PR TITLE
fix : 뒤로 가기 버튼 위치 조정

### DIFF
--- a/frontend/movie-recommend/src/components/movies/MovieDetailInfo.vue
+++ b/frontend/movie-recommend/src/components/movies/MovieDetailInfo.vue
@@ -127,6 +127,11 @@ button {
   flex-wrap: wrap;
 }
 
+.movie-poster {
+  display: flex;
+  flex-direction: column;
+}
+
 .movie-director,
 .movie-actor {
   margin-left: 10px;


### PR DESCRIPTION
## 작업 내용
영화 상세페이지에서 줄거리가 짧은 영화의 경우 뒤로 가기 버튼이 의도와 다른 곳에 위치하는 문제가 있어 수정