### PR TITLE
fix : 401 에러 발생 시 로그인 페이지로 이동하도록 수정

### DIFF
--- a/frontend/movie-recommend/src/components/otts/MyPartyCreated.vue
+++ b/frontend/movie-recommend/src/components/otts/MyPartyCreated.vue
@@ -33,8 +33,10 @@ import disneyplusImage from "@/assets/disneyplus.svg";
 import { ref } from 'vue';
 import axios from "axios";
 import { onMounted } from "vue";
+import { useMovieStore } from "@/stores/movie";
 
 const isModyfing = ref([]);
+const store = useMovieStore();
 
 const props = defineProps({
   ownParties: {
@@ -84,6 +86,9 @@ const updateAccount = (party, index) => {
     })
     .catch((err) => {
       console.error(err);
+      if (err.response.status === 401) {
+        store.solveUnAuthorized(err);
+      }
     });
 };
 </script>

--- a/frontend/movie-recommend/src/components/otts/MyPartyJoined.vue
+++ b/frontend/movie-recommend/src/components/otts/MyPartyJoined.vue
@@ -44,6 +44,7 @@ import watchaImage from "@/assets/watcha.svg";
 import disneyplusImage from "@/assets/disneyplus.svg";
 import axios from 'axios';
 import router from '@/router';
+import { useMovieStore } from '@/stores/movie';
 
 const props = defineProps({
   participateParties: {
@@ -51,6 +52,7 @@ const props = defineProps({
     required: true
   }
 });
+const store = useMovieStore();
 
 const isShow = ref(props.participateParties.map(() => false));
 
@@ -95,6 +97,9 @@ const withdrawParty = (party) => {
     })
     .catch((err)=>{
       console.error(err);
+      if (err.response.status === 401) {
+        store.solveUnAuthorized(err);
+      }
     })
 };
 

--- a/frontend/movie-recommend/src/components/otts/PartyCard.vue
+++ b/frontend/movie-recommend/src/components/otts/PartyCard.vue
@@ -70,6 +70,9 @@ const joinParty = (partyId) => {
     })
     .catch((err) => {
       console.error(err);
+      if (err.response.status === 401) {
+        store.solveUnAuthorized(err);
+      }
     });
 }
 

--- a/frontend/movie-recommend/src/stores/movie.js
+++ b/frontend/movie-recommend/src/stores/movie.js
@@ -20,9 +20,8 @@ export const useMovieStore = defineStore(
     });
 
     const router = useRouter();
-
+    const isLogin = ref(false);
     const API_URL = "http://127.0.0.1:8000";
-    const token = ref(null);
 
     const getRecommendMovies = function (params) {
       return axios({
@@ -94,6 +93,9 @@ export const useMovieStore = defineStore(
         })
         .catch((err) => {
           console.log(err);
+          if (err.response.status === 401) {
+            solveUnAuthorized(err);
+          }
         });
     };
 
@@ -156,7 +158,7 @@ export const useMovieStore = defineStore(
         });
     };
 
-    const isLogin = ref(false);
+
 
     const logOut = function () {
       axios({
@@ -174,8 +176,18 @@ export const useMovieStore = defineStore(
         })
         .catch((error) => {
           console.error(error);
+          if (error.response.status === 401) {
+            solveUnAuthorized(error);
+          }
         });
     };
+
+    const solveUnAuthorized = function(err) {
+      window.alert(err.response.data.detail);
+      isLogin.value = false;
+      localStorage.removeItem('token');
+      router.push({name: 'LoginView'});
+    }
 
     return {
       movies,
@@ -193,6 +205,7 @@ export const useMovieStore = defineStore(
       logIn,
       logOut,
       isLogin,
+      solveUnAuthorized
     };
   },
   { persist: true }

--- a/frontend/movie-recommend/src/views/PartyCreateView.vue
+++ b/frontend/movie-recommend/src/views/PartyCreateView.vue
@@ -148,6 +148,9 @@ const submitForm = () => {
     })
     .catch((err) => {
       console.error(err);
+      if (err.response.status === 401) {
+            store.solveUnAuthorized(err);
+          }
     });
 };
 </script>

--- a/frontend/movie-recommend/src/views/PartyJoinView.vue
+++ b/frontend/movie-recommend/src/views/PartyJoinView.vue
@@ -86,7 +86,12 @@ const fetchParties = (platformsId) => {
       parties.value = res.data;
       // console.log(parties)
     })
-    .catch((err) => console.log(err));
+    .catch((err) => {
+      console.log(err);
+      if (err.response.status === 401) {
+        store.solveUnAuthorized(err);
+      }
+    });
 };
 console.log(parties)
 </script>


### PR DESCRIPTION
## 작업 내용
> 401 에러 발생 시 console.log 에서 그치지 않고 Login 상태 변경 및 로컬 스토리지 토큰 삭제 후 로그인 페이지로 이동하도록 수정했습니다.